### PR TITLE
update openresty to latest rc, use openssl v1.1

### DIFF
--- a/lapis-archlinux/Dockerfile
+++ b/lapis-archlinux/Dockerfile
@@ -1,13 +1,14 @@
 FROM archlinux:latest
 MAINTAINER leaf corcoran <leafot@gmail.com>
 
-RUN pacman -Sy base-devel lua51 lua52 lua53 lua postgresql postgresql-libs luarocks redis tup mariadb libmariadbclient mariadb-clients openssl-1.0 git --noconfirm && (yes | pacman -Scc || :)
+RUN pacman -Sy base-devel lua51 lua52 lua53 lua postgresql postgresql-libs luarocks redis tup mariadb libmariadbclient mariadb-clients openssl-1.1 git --noconfirm && (yes | pacman -Scc || :)
 
 # setup openresty
-RUN curl -O https://openresty.org/download/openresty-1.19.9.1.tar.gz && \
-	tar xvfz openresty-1.19.9.1.tar.gz && \
-	(cd openresty-1.19.9.1 && ./configure --with-pcre-jit --with-cc-opt="-I/usr/include/openssl-1.0" --with-ld-opt="-L/usr/lib/openssl-1.0" && make && make install) && \
-	rm -rf openresty-1.19.9.1 && rm openresty-1.19.9.1.tar.gz
+ARG OPENRESTY_VERSION="1.21.4.2rc1"
+RUN curl -O https://openresty.org/download/openresty-${OPENRESTY_VERSION}.tar.gz && \
+	tar xvfz openresty-${OPENRESTY_VERSION}.tar.gz && \
+	(cd openresty-${OPENRESTY_VERSION} && ./configure --with-pcre-jit --with-cc-opt="-I/usr/include/openssl-1.1" --with-ld-opt="-L/usr/lib/openssl-1.1" && make && make install) && \
+	rm -rf openresty-${OPENRESTY_VERSION} && rm openresty-${OPENRESTY_VERSION}.tar.gz
 
 # setup postgresql
 RUN su postgres -c "initdb --locale en_US.UTF-8 -E UTF8 -D '/var/lib/postgres/data'" && mkdir /run/postgresql && chown postgres:postgres /run/postgresql


### PR DESCRIPTION
* move to the latest OpenResty `v1.21.4.2rc1`, [matching the lapis-archlinux-itchio image](https://github.com/leafo/lapis-archlinux-docker/blob/master/lapis-archlinux-itchio/Dockerfile#L10)
* upgrade OpenSSL to v1.1